### PR TITLE
[Finder] Add case insensitive sort

### DIFF
--- a/components/finder.rst
+++ b/components/finder.rst
@@ -339,13 +339,14 @@ Sorting Results
 Sort the results by name, extension, size or type (directories first, then files)::
 
     $finder->sortByName();
+    $finder->sortByCaseInsensitiveName();
     $finder->sortByExtension();
     $finder->sortBySize();
     $finder->sortByType();
 
 .. versionadded:: 6.2
 
-    The ``sortByExtension()`` and ``sortBySize()`` methods were introduced in Symfony 6.2.
+    The ``sortByCaseInsensitiveName()``, ``sortByExtension()`` and ``sortBySize()`` methods were introduced in Symfony 6.2.
 
 .. tip::
 
@@ -353,6 +354,9 @@ Sort the results by name, extension, size or type (directories first, then files
     function (e.g. ``file1.txt``, ``file10.txt``, ``file2.txt``). Pass ``true``
     as its argument to use PHP's `natural sort order`_ algorithm instead (e.g.
     ``file1.txt``, ``file2.txt``, ``file10.txt``).
+    
+    The ``sortByCaseInsensitiveName()`` method uses the case insensitive :phpfunction:`strcasecmp` PHP function.
+    Pass ``true`` as its argument to use PHP's case insensitive `natural sort order`_ algorithm instead (the :phpfunction:`strnatcasecmp` PHP function)
 
 Sort the files and directories by the last accessed, changed or modified time::
 


### PR DESCRIPTION
Add a new sortByCaseInsensitiveName() method to have case insensitive sorting results.
Like the sortByName(), pass true as its argument to use PHP's case insensitive natural sort order algorithm instead.

Related to #46126 PR
Replace #16735 PR

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
